### PR TITLE
ci: fix release workflows

### DIFF
--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -1,9 +1,21 @@
 name: Create Release Pull Request
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   create_release_pr:
@@ -11,14 +23,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -28,33 +41,30 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Run standard-version (bump version and changelog)
-        run: npx standard-version
+      - name: Run standard-version
+        run: npx standard-version --release-as ${{ inputs.release_type }} --no-verify
 
-      - name: Get new version tag
+      - name: Get new version
         id: get_version
+        shell: bash
         run: |
-          echo "tag=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: v$VERSION"
 
       - name: Create release branch and push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git checkout -b release/v${{ steps.get_version.outputs.tag }}
-          git push origin release/v${{ steps.get_version.outputs.tag }}
+          RELEASE_BRANCH="release/v${{ steps.get_version.outputs.version }}"
+          git checkout -b "$RELEASE_BRANCH"
+          git push origin "$RELEASE_BRANCH"
 
-      - name: Create Pull Request via API
+      - name: Create pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "Content-Type: application/json" \
-            https://api.github.com/repos/${{ github.repository }}/pulls \
-            -d "{\"title\": \"Release v${{ steps.get_version.outputs.tag }}\", \
-                 \"head\": \"release/v${{ steps.get_version.outputs.tag }}\", \
-                 \"base\": \"main\", \
-                 \"body\": \"Release automática da versão v${{ steps.get_version.outputs.tag }}\", \
-                 \"reviewers\": [\"gustavomarques00\"], \
-                 \"assignees\": [\"gustavomarques00\"]}"
+          gh pr create \
+            --title "Release v${{ steps.get_version.outputs.version }}" \
+            --body "Automated release PR for v${{ steps.get_version.outputs.version }}." \
+            --base main \
+            --head "release/v${{ steps.get_version.outputs.version }}" \
+            --assignee "${{ github.actor }}"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -2,33 +2,32 @@ name: Release and Publish
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   publish:
-    if: startsWith(github.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Configure git user for commit
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Publish package to npm
         env:


### PR DESCRIPTION
## Summary

Fix release workflows after the post-merge release job failure.

## Changes

- Make release PR creation manual with `workflow_dispatch`.
- Add release type input: patch, minor, major.
- Update checkout/setup-node actions to v5.
- Use Node.js 24 in release workflows.
- Add explicit workflow permissions.
- Use `gh pr create` for the release PR.
- Publish package only when a version tag `v*.*.*` is pushed.

## Validation

Workflow-only change.