### PR TITLE
ci: make Codecov upload non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Testes e Cobertura
+name: CI - Tests and Coverage
 
 on:
   push:
@@ -6,33 +6,40 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 24.x]
 
     steps:
-      - name: 📥 Checkout do código
-        uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v5
 
-      - name: 🧪 Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
 
-      - name: 📦 Instalar dependências
+      - name: Install dependencies
         run: npm ci
 
-      - name: ✅ Rodar testes com cobertura
+      - name: Run tests with coverage
         run: npm run test:coverage
 
-      - name: 📡 Upload coverage para Codecov
+      - name: Upload coverage to Codecov
+        if: matrix.node-version == '24.x'
         uses: codecov/codecov-action@v5
+        continue-on-error: true
         with:
-          token: ${{ secrets.CODECOV_TOKE }}
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
           verbose: true
         env:
           CODECOV_GPG_VERIFY: false


### PR DESCRIPTION
## Summary

Fixes CI instability caused by Codecov upload failing on GPG signature verification.

## Changes

- Updates checkout/setup-node actions to v5.
- Tests Node 20.x and 24.x.
- Keeps `npm run test:coverage` as the required quality gate.
- Runs Codecov upload only once on Node 24.x.
- Makes Codecov upload non-blocking with `continue-on-error: true` and `fail_ci_if_error: false`.
- Fixes secret name to `CODECOV_TOKEN`.
- Uploads `coverage/lcov.info` explicitly.

## Validation

CI workflow-only change.